### PR TITLE
Fix reports not included in DataTable

### DIFF
--- a/src/components/MoreInfo.vue
+++ b/src/components/MoreInfo.vue
@@ -559,7 +559,7 @@ export default {
         };
         this.$store.dispatch("doReport", report);
       }
-      this.$root.$emit("reloadTable")
+      this.$root.$emit("reloadTable");
     }
   }
 };

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -109,7 +109,9 @@ export default {
           var oid = data.oid;
           app.$store.dispatch("setSelectedCandidate", oid);
           app.$store.dispatch("retrieveAlert", oid);
-          app.$store.dispatch("getReports", oid);
+          if (app.$store.getters.getUser.email != null) {
+            app.$store.dispatch("getReports", oid);
+          }
         }
       },
       "tr"
@@ -139,6 +141,11 @@ export default {
     },
     user() {
       return this.$store.getters.getUser;
+    }
+  },
+  watch: {
+    '$store.state.user': function() {
+      this.reloadTable();
     }
   }
 };

--- a/src/store.js
+++ b/src/store.js
@@ -86,6 +86,7 @@ export default new Vuex.Store({
       var sneCandidates = {};
       $.each(payload, function(key, value) {
         sneCandidates[value["oid"]] = value;
+        sneCandidates[value["oid"]]["report_status"] = null;
       });
       state.sneCandidates = sneCandidates;
     },
@@ -96,11 +97,7 @@ export default new Vuex.Store({
           if(report.object == key)
             return true;
         });
-        if(typeof report !== "undefined") {
-          state.sneCandidates[key]["report_status"] = report["report_type"]
-        } else {
-          state.sneCandidates[key]["report_status"] = null
-        }
+        if(report) state.sneCandidates[key]["report_status"] = report["report_type"];
       });
     },
     CLEAN_CANDIDATES(state) {
@@ -282,7 +279,8 @@ export default new Vuex.Store({
         });
       var last_date = new Date();
       last_date.setDate(date.getDate() - delta);
-      await userApi
+      if (context.getters["getUser"].email != null) {
+        await userApi
         .getReports(null, last_date)
         .then((response) => {
           context.commit("INCLUDE_REPORTS_IN_CANDIDATES", response.data.results);
@@ -290,6 +288,7 @@ export default new Vuex.Store({
         .catch((reason) => {
           context.commit("SET_RESPONSE_REPORT", reason);
         });
+      }
       context.commit("CHANGE_DELTA", delta);
       context.commit("SET_ZOOM", false);
       context.commit("UPDATE_TABLE", context.state.sneCandidates);      


### PR DESCRIPTION
## Context

After Including reports column in SNHunter, the following issue appeared in staging
![Screen Shot 2022-05-19 at 11 14 09](https://user-images.githubusercontent.com/22828010/169335116-d7d131b3-5ad6-4238-aafb-6a6cde8f1eaa.png)

According to the [DataTable doc](https://datatables.net/manual/tech-notes/4) it is because there is no value asigned to that column.

To fix ite we include report status as null when candidates are fetched, and the report are included afterward, if the user is logged in

## Change log

1. At `SET_CANDIDATES` mutation, include `sneCandidates[value["oid"]]["report_status"] = null;`
2.  In `retrieveCandidates` action, only call mutation `INCLUDE_REPORTS_IN_CANDIDATES` when user is logged in

## QA

raplace variables in `.env.development` with

```
NODE_ENV=development
VUE_APP_TITLE=SN Hunter (Develop Build)
VUE_APP_PSQL_API=https://api.alerce.online/ztf/v1
VUE_APP_STAMPS_API=https://avro.alerce.online
VUE_APP_DELTA=2
VUE_APP_USER_API=https://dev.users.alerce.online
VUE_APP_REDIRECT=http://localhost:8080/oauth
```

Although the error of the picture never appeared in local, this may fix the problem in staging.
Check that when there is no logged user and the table is refreshed there is no call to `https://dev.users.alerce.online/` to fetch reports in the network web development tools

