### PR TITLE
Looping user api call

### DIFF
--- a/src/components/MoreInfo.vue
+++ b/src/components/MoreInfo.vue
@@ -559,7 +559,7 @@ export default {
         };
         this.$store.dispatch("doReport", report);
       }
-      this.$root.$emit("reloadTable")
+      this.$root.$emit("reloadTable");
     }
   }
 };

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -109,7 +109,9 @@ export default {
           var oid = data.oid;
           app.$store.dispatch("setSelectedCandidate", oid);
           app.$store.dispatch("retrieveAlert", oid);
-          app.$store.dispatch("getReports", oid);
+          if (app.$store.getters.getUser.email != null) {
+            app.$store.dispatch("getReports", oid);
+          }
         }
       },
       "tr"
@@ -139,6 +141,11 @@ export default {
     },
     user() {
       return this.$store.getters.getUser;
+    }
+  },
+  watch: {
+    '$store.state.user': function() {
+      this.reloadTable();
     }
   }
 };


### PR DESCRIPTION
## Context

1. When a user is not logged and you click on an alter in the table, it call de action `getReports` which call `user_api`, as the user isn't logged in, it fails and the error is not handled well in `userApi.js: 68` as when it fails it calls refresh token entering a loop of: fail > refresh.

2. Also when a user loggs in the table isnt updated, not showing its reports

## Change log

1.  We include an if to check if user is logged in in `Table.vue` call to `getReports`. It is a patch, a true solution should be a correct handling of errors in `userApi.js: 68`
2.  a watcher to `state.user` is implemented in `Table.vue` to trigger a `reloadTable()`

## QA

raplace variables in `.env.development` with

```
NODE_ENV=development
VUE_APP_TITLE=SN Hunter (Develop Build)
VUE_APP_PSQL_API=https://api.alerce.online/ztf/v1
VUE_APP_STAMPS_API=https://avro.alerce.online
VUE_APP_DELTA=2
VUE_APP_USER_API=https://dev.users.alerce.online
VUE_APP_REDIRECT=http://localhost:8080/oauth
```

1. when user not logged open network and click an alert, no looping calls to api_user should appear
2. log tih user: esteban/123qweasd and se if table is updated with reported alerts

